### PR TITLE
Add a real .cyclid.json job file

### DIFF
--- a/.cyclid.json
+++ b/.cyclid.json
@@ -1,0 +1,77 @@
+{
+   "name" : "Mist",
+   "environment":
+      {
+        "os": "ubuntu_trusty",
+        "packages": [
+          "ruby2.0",
+          "ruby2.0-dev",
+          "build-essential",
+          "git",
+          "zlib1g-dev"
+        ]
+      },
+   "stages" : [
+      {
+         "name" : "checkout",
+         "steps" : [
+            {
+               "action" : "command",
+               "cmd" : "git clone https://9fdeb8455415c9c9d1a91a73410a7bf91b5b63c2@github.com/Liqwyd/Mist.git"
+            }
+         ]
+      },
+      {
+        "name" : "bundle-install",
+        "steps" : [
+          {
+            "action" : "command", 
+            "cmd" : "sudo gem2.0 install bundler --no-ri --no-doc"
+          },
+          {
+            "action" : "command",
+            "cmd": "bundle install --without lxc gce --path vendor/bundle",
+            "path" : "/home/build/Mist"
+          }
+        ]
+      },
+      {
+        "name" : "lint",
+        "steps" : [
+          {
+            "action" : "command",
+            "cmd" : "bundle exec rake rubocop",
+            "path" : "/home/build/Mist"
+          },
+          {
+            "action" : "command",
+            "cmd" : "bundle exec rake doc",
+            "path" : "/home/build/Mist"
+          }
+        ]
+      }
+   ],
+   "sequence" : [
+      {
+         "stage" : "checkout",
+         "on_success" : "bundle-install",
+         "on_failure" : "failure"
+      },
+      {
+         "stage" : "bundle-install",
+         "on_success" : "lint",
+         "on_failure" : "failure"
+      },
+      {
+        "stage" : "lint",
+        "on_success" : "success",
+        "on_failure" : "failure"
+      },
+      {
+         "stage" : "success"
+      },
+      {
+         "stage" : "failure"
+      }
+   ]
+}

--- a/.cyclid.json
+++ b/.cyclid.json
@@ -22,7 +22,7 @@
           {
             "action" : "command",
             "cmd": "bundle install --without lxc gce --path vendor/bundle",
-            "path" : "/home/build/Mist"
+            "path" : "%{workspace}/Mist"
           }
         ]
       },
@@ -32,12 +32,12 @@
           {
             "action" : "command",
             "cmd" : "bundle exec rake rubocop",
-            "path" : "/home/build/Mist"
+            "path" : "%{workspace}/Mist"
           },
           {
             "action" : "command",
             "cmd" : "bundle exec rake doc",
-            "path" : "/home/build/Mist"
+            "path" : "%{workspace}/Mist"
           }
         ]
       }

--- a/.cyclid.json
+++ b/.cyclid.json
@@ -13,15 +13,6 @@
       },
    "stages" : [
       {
-         "name" : "checkout",
-         "steps" : [
-            {
-               "action" : "command",
-               "cmd" : "git clone https://9fdeb8455415c9c9d1a91a73410a7bf91b5b63c2@github.com/Liqwyd/Mist.git"
-            }
-         ]
-      },
-      {
         "name" : "bundle-install",
         "steps" : [
           {
@@ -52,11 +43,6 @@
       }
    ],
    "sequence" : [
-      {
-         "stage" : "checkout",
-         "on_success" : "bundle-install",
-         "on_failure" : "failure"
-      },
       {
          "stage" : "bundle-install",
          "on_success" : "lint",


### PR DESCRIPTION
Copy in the job file we've already tested; this will genuinely cause Mist to
be linted & built on pull requests.